### PR TITLE
Avoid adding hooks on deferred field subclasses

### DIFF
--- a/django_auto_one_to_one/models.py
+++ b/django_auto_one_to_one/models.py
@@ -104,6 +104,10 @@ def AutoOneToOneModel(parent, related_name=None, attr=None):
 
             if model._meta.abstract:
                 return model
+            
+            # Avoid virtual models (for, for instance, deferred fields)
+            if model._meta.concrete_model is not model:
+                return model
 
             # Setup the signals that will automatically create and destroy
             # instances.


### PR DESCRIPTION
Django occasionally creates its own subclasses of models, for `.only` or `.defer`. We don't want to connect up `on_create` and `on_delete` for these virtual subclasses, because the former case will cause errors with with the uniqueness constraint when it adds records multiple times.
